### PR TITLE
Sata eject issue

### DIFF
--- a/bin/vm-snap-create
+++ b/bin/vm-snap-create
@@ -1,9 +1,14 @@
 #!/bin/bash
 
+: ${DISK_FORMAT:='qcow2'}
 : ${DISK_PATH:='/image'}
 : ${BOOTLOADER_AS_USB:='Y'}
 
-BOOTLOADER_FULLPATH="${DISK_PATH%/}/bootloader.raw"
+[[ ! "${BOOTLOADER_AS_USB}" == [Yy1]* ]] && [[ ! "${DISK_FORMAT}" == "qcow2" ]] \
+	&& echo "ERROR: Unsupported disk format: ${DISK_FORMAT} (only qcow2 support live snapshot)" \
+	&& exit 254
+
+BOOTLOADER_FULLPATH="${DISK_PATH%/}/bootloader.${DISK_FORMAT}"
 DEV_TYPE="sata"
 rc=0
 
@@ -12,41 +17,38 @@ rc=0
 echo "#      Creating live snapshot      #"
 echo "# ################################ #"
 
-echo ""
-echo "#### INFO: Ejecting bootloader ${DEV_TYPE} disk ..."
-[[ "${DEV_TYPE}" == "usb" ]] \
-	&& echo "eject drive-${DEV_TYPE}-disk-bootloader" | nc -U /run/qemu-monitor.sock \
-	|| echo "drive_del drive-${DEV_TYPE}-disk-bootloader" | nc -U /run/qemu-monitor.sock
-echo ""
 
-echo "info block" | nc -U /run/qemu-monitor.sock | grep -q "${BOOTLOADER_FULLPATH}"
-rc=$?
-[[ $rc -ne 0 ]] \
-	&& echo "## INFO: Bootloader ${DEV_TYPE} disk has been ejected successfully." \
-	|| ( echo "## ERROR: Bootloader ${DEV_TYPE} disk has NOT been ejected. Make sure it's not in use!" && exit 1 )
-echo ""
+if [[ "${DEV_TYPE}" == "usb" ]]; then
+	echo ""
+	echo "#### INFO: Ejecting bootloader ${DEV_TYPE} disk ..."
+	cat <<- __EOF__ | nc -U /run/qemu-monitor.sock | grep -q "${BOOTLOADER_FULLPATH}"
+		eject -f drive-disk-bootloader
+		info block
+	__EOF__
+	rc=$?
+	echo ""
+	[[ $rc -ne 0 ]] \
+		&& echo "## INFO: Bootloader ${DEV_TYPE} disk has been ejected successfully." \
+		|| ( echo "## ERROR: Bootloader ${DEV_TYPE} disk has NOT been ejected. Make sure it's not in use!" && exit 2 )
+	echo ""
+	
+fi
 
 echo ""
 echo "#### INFO: Saving vm ..."
 echo savevm $1 | nc -U /run/qemu-monitor.sock
 echo "" 
 
-echo ""
-echo "#### INFO: Reinserting bootloader ${DEV_TYPE} disk ..."
 if [[ "${DEV_TYPE}" == "usb" ]]; then
-	echo "change drive-${DEV_TYPE}-disk-bootloader ${BOOTLOADER_FULLPATH} ${BOOTLOADER_FULLPATH##*.}" | nc -U /run/qemu-monitor.sock
-else
-	cat <<- __EOF__ | nc -U /run/qemu-monitor.sock
-		drive_add 0 "file=${BOOTLOADER_FULLPATH},if=none,id=drive-${DEV_TYPE}-disk-bootloader,format=${BOOTLOADER_FULLPATH##*.},cache=none,aio=native,detect-zeroes=on"
-		device_add "ide-hd,bus=ahci0.0,drive=drive-${DEV_TYPE}-disk-bootloader,id=sata-disk-bootloader,bootindex=100"
+	echo ""
+	echo "#### INFO: Reinserting bootloader ${DEV_TYPE} disk ..."
+	cat <<- __EOF__ | nc -U /run/qemu-monitor.sock | grep -q "drive-disk-bootloader.*${BOOTLOADER_FULLPATH}"
+		change drive-disk-bootloader ${BOOTLOADER_FULLPATH} ${BOOTLOADER_FULLPATH##*.}
+		info block
 	__EOF__
+	echo ""
+	rc=$?
+	[[ $rc -eq 0 ]] && echo "## INFO: Bootloader ${DEV_TYPE} disk has been reinserted successfully..." \
+		|| ( echo "## WARNING: Bootloader ${DEV_TYPE} disk has NOT been reinserted. You may have boot issue on reset." && exit $rc )
+	echo ""
 fi
-echo ""
-
-echo "info block" | nc -U /run/qemu-monitor.sock | grep -q "drive-${DEV_TYPE}-disk-bootloader.*${BOOTLOADER_FULLPATH}"
-rc=$?
-[[ $rc -eq 0 ]] && echo "## INFO: Bootloader ${DEV_TYPE} disk has been reinserted successfully..." \
-	|| ( echo "## WARNING: Bootloader ${DEV_TYPE} disk has NOT been reinserted. You may have boot issue on reset." && exit $rc )
-echo ""
-
-exit $rc

--- a/bin/vm-snap-restore
+++ b/bin/vm-snap-restore
@@ -4,10 +4,16 @@
 	&& echo "ERROR: Missing argument: string expected" \
 	&& exit 254
 
+
+: ${DISK_FORMAT:='qcow2'}
 : ${DISK_PATH:='/image'}
 : ${BOOTLOADER_AS_USB:='Y'}
 
-BOOTLOADER_FULLPATH="${DISK_PATH%/}/bootloader.raw"
+[[ ! "${BOOTLOADER_AS_USB}" == [Yy1]* ]] && [[ ! "${DISK_FORMAT}" == "qcow2" ]] \
+	&& echo "ERROR: Unsupported disk format: ${DISK_FORMAT} (only qcow2 support live snapshot)" \
+	&& exit 254
+
+BOOTLOADER_FULLPATH="${DISK_PATH%/}/bootloader.${DISK_FORMAT}"
 DEV_TYPE="sata"
 rc=0
 
@@ -16,41 +22,38 @@ rc=0
 echo "#     Restoring live snapshot      #"
 echo "# ################################ #"
 
-echo ""
-echo "#### INFO: Ejecting bootloader ${DEV_TYPE} disk ..."
-[[ "${DEV_TYPE}" == "usb" ]] \
-	&& echo "eject drive-${DEV_TYPE}-disk-bootloader" | nc -U /run/qemu-monitor.sock \
-	|| echo "drive_del drive-${DEV_TYPE}-disk-bootloader" | nc -U /run/qemu-monitor.sock
-echo ""
 
-echo "info block" | nc -U /run/qemu-monitor.sock | grep -q "${BOOTLOADER_FULLPATH}"
-rc=$?
-[[ $rc -ne 0 ]] \
-	&& echo "## INFO: Bootloader ${DEV_TYPE} disk has been ejected successfully." \
-	|| ( echo "## ERROR: Bootloader ${DEV_TYPE} disk has NOT been ejected. Make sure it's not in use!" && exit 1 )
-echo ""
+if [[ "${DEV_TYPE}" == "usb" ]]; then
+	echo ""
+	echo "#### INFO: Ejecting bootloader ${DEV_TYPE} disk ..."
+	cat <<- __EOF__ | nc -U /run/qemu-monitor.sock | grep -q "${BOOTLOADER_FULLPATH}"
+		eject -f drive-disk-bootloader
+		info block
+	__EOF__
+	rc=$?
+	echo ""
+	[[ $rc -ne 0 ]] \
+		&& echo "## INFO: Bootloader ${DEV_TYPE} disk has been ejected successfully." \
+		|| ( echo "## ERROR: Bootloader ${DEV_TYPE} disk has NOT been ejected. Make sure it's not in use!" && exit 2 )
+	echo ""
+	
+fi
 
 echo ""
 echo "#### INFO: Loading vm ..."
 echo loadvm $1 | nc -U /run/qemu-monitor.sock
 echo "" 
 
-echo ""
-echo "#### INFO: Reinserting bootloader ${DEV_TYPE} disk ..."
 if [[ "${DEV_TYPE}" == "usb" ]]; then
-	echo "change drive-${DEV_TYPE}-disk-bootloader ${BOOTLOADER_FULLPATH} ${BOOTLOADER_FULLPATH##*.}" | nc -U /run/qemu-monitor.sock
-else
-	cat <<- __EOF__ | nc -U /run/qemu-monitor.sock
-		drive_add 0 "file=${BOOTLOADER_FULLPATH},if=none,id=drive-${DEV_TYPE}-disk-bootloader,format=${BOOTLOADER_FULLPATH##*.},cache=none,aio=native,detect-zeroes=on"
-		device_add "ide-hd,bus=ahci0.0,drive=drive-${DEV_TYPE}-disk-bootloader,id=sata-disk-bootloader,bootindex=100"
+	echo ""
+	echo "#### INFO: Reinserting bootloader ${DEV_TYPE} disk ..."
+	cat <<- __EOF__ | nc -U /run/qemu-monitor.sock | grep -q "drive-disk-bootloader.*${BOOTLOADER_FULLPATH}"
+		change drive-disk-bootloader ${BOOTLOADER_FULLPATH} ${BOOTLOADER_FULLPATH##*.}
+		info block
 	__EOF__
+	echo ""
+	rc=$?
+	[[ $rc -eq 0 ]] && echo "## INFO: Bootloader ${DEV_TYPE} disk has been reinserted successfully..." \
+		|| ( echo "## WARNING: Bootloader ${DEV_TYPE} disk has NOT been reinserted. You may have boot issue on reset." && exit $rc )
+	echo ""
 fi
-echo ""
-
-echo "info block" | nc -U /run/qemu-monitor.sock | grep -q "drive-${DEV_TYPE}-disk-bootloader.*${BOOTLOADER_FULLPATH}"
-rc=$?
-[[ $rc -eq 0 ]] && echo "## INFO: Bootloader ${DEV_TYPE} disk has been reinserted successfully..." \
-	|| ( echo "## WARNING: Bootloader ${DEV_TYPE} disk has NOT been reinserted. You may have boot issue on reset." && exit $rc )
-echo ""
-
-exit $rc

--- a/bin/vm-startup
+++ b/bin/vm-startup
@@ -122,32 +122,37 @@ if [[ ! -f ${BOOTLOADER_FULLPATH} ]] ; then
 		|| ( log "ERROR" "Bootloader cannot be downloaded from URL." && exit 10 )
 fi
 
-# Changed bootloader size checking from error to warning
+# Check bootloader file size, and throw a warning only
 find ${DISK_PATH} -name ${BOOTLOADER_FULLPATH##*/} -size +48M -size -52M | grep -q . \
 	&& log "INFO" "${BOOTLOADER_FULLPATH} file size seems valid for synoboot." \
 	|| ( log "WARNING" "${BOOTLOADER_FULLPATH} file size does not seem correct for synoboot." )
 
-# Convert bootloader to other format (qcow2 for now)
-#[[ ${DISK_FORMAT} == "qcow2" ]] \
-#	&& qemu-img convert -f raw -O ${DISK_FORMAT} ${BOOTLOADER_FULLPATH} ${BOOTLOADER_FULLPATH%.img}.${DISK_FORMAT} \
-#	&& log "INFO" "Bootloader has been converted to ${DISK_FORMAT}" \
-#	&& BOOTLOADER_FULLPATH=${BOOTLOADER_FULLPATH%.img}.${DISK_FORMAT}
+# Convert bootloader to other format (only qcow2 for now)
+if [[ ${DISK_FORMAT} == "qcow2" ]]; then
+	if [[ ! -f ${BOOTLOADER_FULLPATH%.raw}.${DISK_FORMAT} ]]; then
+		qemu-img convert -f raw -O ${DISK_FORMAT} ${BOOTLOADER_FULLPATH} ${BOOTLOADER_FULLPATH%.raw}.${DISK_FORMAT} \
+			&& log "INFO" "Bootloader has been converted to ${DISK_FORMAT}" \
+			|| ( log "ERROR" "Cannot convert Bootloader to ${DISK_FORMAT}. Exiting." && exit 20 )
+	fi
+	BOOTLOADER_FULLPATH=${BOOTLOADER_FULLPATH%.raw}.${DISK_FORMAT}
+fi
 
 # Set bootloader as USB or as SATA disk
 # ######################################
-KVM_SYNOBOOT="-device 'ahci,id=ahci0,multifunction=on,bus=pcie.0,addr=0x7'"
+KVM_SYNOBOOT="${KVM_SYNOBOOT} -device 'ahci,id=ahci0,multifunction=on,bus=pcie.0,addr=0x7'"
+KVM_SYNOBOOT="${KVM_SYNOBOOT} -device 'ich9-usb-ehci1,id=usb-bus0,multifunction=on'"
+KVM_SYNOBOOT="${KVM_SYNOBOOT} -drive 'file=${BOOTLOADER_FULLPATH},format=${BOOTLOADER_FULLPATH##*.},if=none,id=drive-disk-bootloader,cache=none,aio=native,detect-zeroes=on'"
 
 if [[ "${BOOTLOADER_AS_USB}" == [Yy1]* ]]; then
-	KVM_SYNOBOOT="${KVM_SYNOBOOT} -device 'ich9-usb-ehci1,id=usb-hub0,multifunction=on' -drive 'file=${BOOTLOADER_FULLPATH},format=${BOOTLOADER_FULLPATH##*.},if=none,id=drive-usb-disk-bootloader,cache=writeback' -device 'usb-storage,bus=usb-hub0.0,port=1,drive=drive-usb-disk-bootloader,id=usb-disk-bootloader,bootindex=100,removable=on'"
+	KVM_SYNOBOOT="${KVM_SYNOBOOT} -device 'usb-storage,bus=usb-bus0.0,port=1,drive=drive-disk-bootloader,id=usb-disk-bootloader,bootindex=100,removable=on'"
 else
 	# Use bootloader as first sata disk
-	KVM_SYNOBOOT="${KVM_SYNOBOOT} -drive 'file=${BOOTLOADER_FULLPATH},if=none,id=drive-sata-disk-bootloader,format=${BOOTLOADER_FULLPATH##*.},cache=none,aio=native,detect-zeroes=on'"
 	KVM_SYNOBOOT="${KVM_SYNOBOOT} -device 'ide-hd,bus=ahci0.0,drive=drive-sata-disk-bootloader,id=sata-disk-bootloader,bootindex=100'"
 fi
 
 # Add SATA disks
 # ######################################
-TMP_KVM_BLK_OPTS=""
+TMP_KVM_BLK_OPTS="${TMP_KVM_BLK_OPTS}"
 i=0
 for size in $DISK_SIZE ; do
 	((++i))

--- a/bin/vm-startup
+++ b/bin/vm-startup
@@ -118,7 +118,7 @@ done
 if [[ ! -f ${BOOTLOADER_FULLPATH} ]] ; then
 	log "INFO" "Start downloading bootloader from URL ..."
 	wget --no-check-certificate -q --show-progress --progress=dot:giga ${BOOTLOADER_URL} -O ${BOOTLOADER_FULLPATH} \
-		&& log "INFO" "Bootloader has been successfully downloaded from URL." \
+		&& echo "" && log "INFO" "Bootloader has been successfully downloaded from URL." \
 		|| ( log "ERROR" "Bootloader cannot be downloaded from URL." && exit 10 )
 fi
 
@@ -147,7 +147,7 @@ if [[ "${BOOTLOADER_AS_USB}" == [Yy1]* ]]; then
 	KVM_SYNOBOOT="${KVM_SYNOBOOT} -device 'usb-storage,bus=usb-bus0.0,port=1,drive=drive-disk-bootloader,id=usb-disk-bootloader,bootindex=100,removable=on'"
 else
 	# Use bootloader as first sata disk
-	KVM_SYNOBOOT="${KVM_SYNOBOOT} -device 'ide-hd,bus=ahci0.0,drive=drive-sata-disk-bootloader,id=sata-disk-bootloader,bootindex=100'"
+	KVM_SYNOBOOT="${KVM_SYNOBOOT} -device 'ide-hd,bus=ahci0.0,drive=drive-disk-bootloader,id=sata-disk-bootloader,bootindex=100'"
 fi
 
 # Add SATA disks


### PR DESCRIPTION
Sata cannot be ejected then reinserted if the right module are not loaded.
So sata ejection for live snapshot have been removed.

Raw bootloader as sata disk does not work with live snapshot,
so Bootloaded is now converted to qcow2 (if chosen) to get live snapshot working (as sata).
